### PR TITLE
Dev/qb 106

### DIFF
--- a/src/main/kotlin/quickfix/bootstrap/DataInitializer.kt
+++ b/src/main/kotlin/quickfix/bootstrap/DataInitializer.kt
@@ -173,7 +173,6 @@ class DataInitializer : InitializingBean {
             name = "Valentina"
             lastName = "Gomez"
             dni = 12345678
-            avatar = "imgValen1"
             dateBirth = LocalDate.of(1995, 5, 23)
             gender = Gender.FEMALE
             address = address1
@@ -191,7 +190,6 @@ class DataInitializer : InitializingBean {
             name = "Cristina"
             lastName = "Palacios"
             dni = 12345679
-            avatar = "imgCris2"
             dateBirth = LocalDate.of(1995, 5, 23)
             gender = Gender.FEMALE
             address = address2
@@ -209,7 +207,6 @@ class DataInitializer : InitializingBean {
             name = "Tomaso"
             lastName = "Perez"
             dni = 12345671
-            avatar = "imgTomi3"
             dateBirth = LocalDate.of(1995, 5, 23)
             gender = Gender.FEMALE
             address = address3
@@ -227,7 +224,6 @@ class DataInitializer : InitializingBean {
             name = "Juan"
             lastName = "Contardo"
             dni = 12345672
-            avatar = "imgJuan4"
             dateBirth = LocalDate.of(1995, 5, 23)
             gender = Gender.MALE
             address = address4
@@ -244,7 +240,6 @@ class DataInitializer : InitializingBean {
             name = "Rodrigo"
             lastName = "Bueno"
             dni = 12345673
-            avatar = "imgRodri5"
             dateBirth = LocalDate.of(1995, 5, 23)
             gender = Gender.OTHER
             address = address5
@@ -261,7 +256,6 @@ class DataInitializer : InitializingBean {
             name = "Fer"
             lastName = "Dodino"
             dni = 12345674
-            avatar = "imgFer6"
             dateBirth = LocalDate.of(1995, 5, 23)
             gender = Gender.FEMALE
             address = address6

--- a/src/main/kotlin/quickfix/controllers/UserController.kt
+++ b/src/main/kotlin/quickfix/controllers/UserController.kt
@@ -36,7 +36,9 @@ class UserController(
     @PatchMapping("/avatar")
     fun updateAvatar(@ModelAttribute("currentUserId") currentUserId: Long, @RequestParam("file") file: MultipartFile) =
         userService.updateAvatar(currentUserId, file)
+        
     @GetMapping("/avatar")
-    fun getAvatar(@ModelAttribute("currentUserId") currentUserId: Long) = userService.getAvatar(currentUserId)
+    fun getAvatar(@ModelAttribute("currentUserId") currentUserId: Long) = 
+        userService.getAvatar(currentUserId)
 
 }

--- a/src/main/kotlin/quickfix/controllers/UserController.kt
+++ b/src/main/kotlin/quickfix/controllers/UserController.kt
@@ -3,6 +3,7 @@ package quickfix.controllers
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 import quickfix.dto.user.UserDTO
 import quickfix.dto.user.UserModifiedInfoDTO
 import quickfix.services.UserService
@@ -33,7 +34,9 @@ class UserController(
         userService.changeUserInfo(currentUserId, modifiedInfo)
 
     @PatchMapping("/avatar")
-    fun updateAvatar(@ModelAttribute("currentUserId") currentUserId: Long, @RequestBody avatar: String) =
-        userService.updateAvatar(currentUserId, avatar)
+    fun updateAvatar(@ModelAttribute("currentUserId") currentUserId: Long, @RequestParam("file") file: MultipartFile) =
+        userService.updateAvatar(currentUserId, file)
+    @GetMapping("/avatar")
+    fun getAvatar(@ModelAttribute("currentUserId") currentUserId: Long) = userService.getAvatar(currentUserId)
 
 }

--- a/src/main/kotlin/quickfix/controllers/UserController.kt
+++ b/src/main/kotlin/quickfix/controllers/UserController.kt
@@ -25,11 +25,15 @@ class UserController(
         UserDTO.toDTO(userService.getUserById(currentUserId))
 
     @GetMapping("/img")
-    fun userImg(@ModelAttribute("currentUserId") currentUserId : Long) : String =
+    fun userImg(@ModelAttribute("currentUserId") currentUserId : Long) : ByteArray =
         userService.getUserById(currentUserId).avatar
 
     @PatchMapping("/data/edit")
     fun updateUserInfo(@ModelAttribute("currentUserId") currentUserId : Long, @RequestBody modifiedInfo: UserModifiedInfoDTO) =
         userService.changeUserInfo(currentUserId, modifiedInfo)
+
+    @PatchMapping("/avatar")
+    fun updateAvatar(@ModelAttribute("currentUserId") currentUserId: Long, @RequestBody avatar: String) =
+        userService.updateAvatar(currentUserId, avatar)
 
 }

--- a/src/main/kotlin/quickfix/dto/professional/ProfessionalDTO.kt
+++ b/src/main/kotlin/quickfix/dto/professional/ProfessionalDTO.kt
@@ -2,6 +2,7 @@ package quickfix.dto.professional
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
+import quickfix.models.User
 
 data class ProfessionalDTO @JsonCreator constructor(
     @JsonProperty("id")             var id: Long,
@@ -13,7 +14,7 @@ data class ProfessionalDTO @JsonCreator constructor(
 ){
     companion object {
 
-        fun fromUser(user: quickfix.models.User, averageRating: Double): ProfessionalDTO {
+        fun fromUser(user: User, averageRating: Double): ProfessionalDTO {
            return ProfessionalDTO(
                 id = user.id,
                 name = user.name,

--- a/src/main/kotlin/quickfix/dto/professional/ProfessionalDTO.kt
+++ b/src/main/kotlin/quickfix/dto/professional/ProfessionalDTO.kt
@@ -2,7 +2,7 @@ package quickfix.dto.professional
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
-
+import java.util.Base64
 data class ProfessionalDTO @JsonCreator constructor(
     @JsonProperty("id")             var id: Long,
     @JsonProperty("name")           var name: String,
@@ -13,16 +13,20 @@ data class ProfessionalDTO @JsonCreator constructor(
     @JsonProperty("hasVehicle")     var hasVehicle: Boolean
 ){
     companion object {
-        fun fromUser(user: quickfix.models.User, averageRating: Double): ProfessionalDTO =
-            ProfessionalDTO(
-                id            = user.id,
-                name          = user.name,
-                lastName      = user.lastName,
-                avatar        = user.avatar,
-                verified      = user.verified,
+
+        fun fromUser(user: quickfix.models.User, averageRating: Double): ProfessionalDTO {
+            val avatarBase64 = user.avatar.let { Base64.getEncoder().encodeToString(it) }
+                ?: ""
+           return ProfessionalDTO(
+                id = user.id,
+                name = user.name,
+                lastName = user.lastName,
+                avatar = avatarBase64,
+                verified = user.verified,
                 averageRating = averageRating,
-                hasVehicle    = user.professionalInfo.hasVehicle
+                hasVehicle = user.professionalInfo.hasVehicle
             )
+        }
     }
 }
 

--- a/src/main/kotlin/quickfix/dto/professional/ProfessionalDTO.kt
+++ b/src/main/kotlin/quickfix/dto/professional/ProfessionalDTO.kt
@@ -2,12 +2,11 @@ package quickfix.dto.professional
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.Base64
+
 data class ProfessionalDTO @JsonCreator constructor(
     @JsonProperty("id")             var id: Long,
     @JsonProperty("name")           var name: String,
     @JsonProperty("lastName")       var lastName: String,
-    @JsonProperty("avatar")         var avatar: String,
     @JsonProperty("verified")       var verified: Boolean,
     @JsonProperty("averageRating")  var averageRating: Double,
     @JsonProperty("hasVehicle")     var hasVehicle: Boolean
@@ -15,13 +14,10 @@ data class ProfessionalDTO @JsonCreator constructor(
     companion object {
 
         fun fromUser(user: quickfix.models.User, averageRating: Double): ProfessionalDTO {
-            val avatarBase64 = user.avatar.let { Base64.getEncoder().encodeToString(it) }
-                ?: ""
            return ProfessionalDTO(
                 id = user.id,
                 name = user.name,
                 lastName = user.lastName,
-                avatar = avatarBase64,
                 verified = user.verified,
                 averageRating = averageRating,
                 hasVehicle = user.professionalInfo.hasVehicle

--- a/src/main/kotlin/quickfix/dto/register/RegisterRequestDTO.kt
+++ b/src/main/kotlin/quickfix/dto/register/RegisterRequestDTO.kt
@@ -12,7 +12,6 @@ class RegisterRequestDTO (
     var lastName: String,
     var rawPassword: String,
     var dni: Int,
-    var avatar: String,
     var dateBirth: String,
     var gender: Gender,
     var address: Address,
@@ -27,7 +26,6 @@ fun RegisterRequestDTO.toUser() : User {
         name = request.name.trim()
         lastName = request.lastName.trim()
         dni = request.dni
-        avatar =  Base64.getDecoder().decode(request.avatar.trim())
         dateBirth = datifyStringWithDay(request.dateBirth)
         gender = request.gender
         address = request.address

--- a/src/main/kotlin/quickfix/dto/register/RegisterRequestDTO.kt
+++ b/src/main/kotlin/quickfix/dto/register/RegisterRequestDTO.kt
@@ -4,6 +4,7 @@ import quickfix.models.Address
 import quickfix.models.Gender
 import quickfix.models.User
 import quickfix.utils.datifyStringWithDay
+import java.util.Base64
 
 class RegisterRequestDTO (
     var mail: String,
@@ -19,12 +20,14 @@ class RegisterRequestDTO (
 
 fun RegisterRequestDTO.toUser() : User {
     val request : RegisterRequestDTO = this
+
     return User().apply {
+
         mail = request.mail.trim()
         name = request.name.trim()
         lastName = request.lastName.trim()
         dni = request.dni
-        avatar = request.avatar.trim()
+        avatar =  Base64.getDecoder().decode(request.avatar.trim())
         dateBirth = datifyStringWithDay(request.dateBirth)
         gender = request.gender
         address = request.address

--- a/src/main/kotlin/quickfix/models/User.kt
+++ b/src/main/kotlin/quickfix/models/User.kt
@@ -34,6 +34,8 @@ class User : Identifier {
     lateinit var mail: String
     lateinit var name : String
     lateinit var lastName : String
+
+    @Lob
     lateinit var avatar: ByteArray
     lateinit var dateBirth : LocalDate
     var verified : Boolean = false

--- a/src/main/kotlin/quickfix/models/User.kt
+++ b/src/main/kotlin/quickfix/models/User.kt
@@ -34,7 +34,7 @@ class User : Identifier {
     lateinit var mail: String
     lateinit var name : String
     lateinit var lastName : String
-    lateinit var avatar: String
+    lateinit var avatar: ByteArray
     lateinit var dateBirth : LocalDate
     var verified : Boolean = false
 

--- a/src/main/kotlin/quickfix/services/UserService.kt
+++ b/src/main/kotlin/quickfix/services/UserService.kt
@@ -2,12 +2,14 @@ package quickfix.services
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
 import quickfix.dao.UserRepository
 import quickfix.dto.user.UserModifiedInfoDTO
 import quickfix.models.Profession
 import quickfix.models.ProfessionalInfo
 import quickfix.models.User
 import quickfix.utils.exceptions.BusinessException
+import java.util.Base64
 
 @Service
 class UserService(
@@ -39,6 +41,12 @@ class UserService(
     fun changeUserInfo(id: Long, modifiedInfo: UserModifiedInfoDTO) {
         val user = this.getUserById(id)
         user.updateUserInfo(modifiedInfo)
+    }
+    @Transactional(rollbackFor = [Exception::class])
+    fun updateAvatar(currentUserId: Long, avatarBase64: String) {
+        val user = this.getUserById(currentUserId)
+        user.avatar = Base64.getDecoder().decode(avatarBase64.trim())
+        userRepository.save(user)
     }
 
 }

--- a/src/main/kotlin/quickfix/services/UserService.kt
+++ b/src/main/kotlin/quickfix/services/UserService.kt
@@ -43,10 +43,9 @@ class UserService(
         user.updateUserInfo(modifiedInfo)
     }
     @Transactional(rollbackFor = [Exception::class])
-    fun updateAvatar(currentUserId: Long, avatarBase64: String) {
+    fun updateAvatar(currentUserId: Long, file: MultipartFile) {
         val user = this.getUserById(currentUserId)
-        user.avatar = Base64.getDecoder().decode(avatarBase64.trim())
-        userRepository.save(user)
+        user.avatar = file.bytes
     }
-
+    fun getAvatar(userId: Long): ByteArray = this.getUserById(userId).avatar
 }


### PR DESCRIPTION
1. en el dataInizalaizer se elimina todas referencias a avatar debido a q avatar pasa a ser de tipo string -> ByteArray 
2.  en el userController se agregan los endpoint de updateAvatar y getAvatar
3.  en RegisterUserDTO ya no se puede mandar el avatar al registrarse
4.  en ProfessionalDTO se elimina la referencia a avatar
5. en en el service se agrega updateAvatar y getAvatar

abria q buscar la manera de cargar x defecto imagenes
concidero q tanto al registarse como al actualizar la informacion el usuario esos endpoint no deberian tener vinculacion alguna con el avatar 

![avatar](https://github.com/user-attachments/assets/79ae06fe-9c2d-4469-a8ce-62e01005934f)


