### PR TITLE
Dev/qb 109

### DIFF
--- a/src/main/kotlin/quickfix/controllers/JobController.kt
+++ b/src/main/kotlin/quickfix/controllers/JobController.kt
@@ -41,14 +41,13 @@ class JobController(
 
     @GetMapping("/customer")
     @Operation(summary = "Obtiene todos los servicios pedidos por un usuario")
-    fun findJobsByCustomerId(@ModelAttribute("currentCustomerId") currentCustomerId : Long,
-                             @RequestParam pageNumber: Int) : PageDTO<JobDTO> =
+    fun findJobsByCustomerId(
+        @ModelAttribute("currentCustomerId") currentCustomerId : Long, @RequestParam pageNumber: Int) : PageDTO<JobDTO> =
         PageDTO.toDTO(jobService.findJobsByCustomerId(currentCustomerId, pageNumber).map{ job -> toDto(job)  })
 
     @GetMapping("/professional")
     @Operation(summary = "Obtiene todos los servicios realizados por un profesional")
-    fun findJobsByProfessionalId(@ModelAttribute("currentProfessionalId") currentProfessionalId : Long,
-                                 @RequestParam pageNumber: Int) : PageDTO<JobDTO> =
+    fun findJobsByProfessionalId(@ModelAttribute("currentProfessionalId") currentProfessionalId : Long, @RequestParam pageNumber: Int) : PageDTO<JobDTO> =
         PageDTO.toDTO(jobService.findJobsByProfessionalId(currentProfessionalId, pageNumber).map{ job -> toDto(job)  })
 
     @PatchMapping("/complete/{id}")

--- a/src/main/kotlin/quickfix/controllers/JobController.kt
+++ b/src/main/kotlin/quickfix/controllers/JobController.kt
@@ -8,6 +8,7 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 import quickfix.dto.job.JobDTO
+import quickfix.dto.job.PageDTO
 import quickfix.dto.job.jobOffer.AcceptedJobOfferDTO
 import quickfix.dto.job.jobOffer.CancelJobOfferDTO
 import quickfix.dto.job.jobOffer.CreateJobOfferDTO
@@ -41,16 +42,14 @@ class JobController(
     @GetMapping("/customer")
     @Operation(summary = "Obtiene todos los servicios pedidos por un usuario")
     fun findJobsByCustomerId(@ModelAttribute("currentCustomerId") currentCustomerId : Long,
-                             @RequestParam("q", required = false) filter: String?,
-                             @PageableDefault(page = 0, size = 10) pageable: Pageable
-    ) : Page<JobDTO> = jobService.findJobsByCustomerId(currentCustomerId, pageable).map{ job -> toDto(job)  }
+                             @RequestParam pageNumber: Int) : PageDTO<JobDTO> =
+        PageDTO.toDTO(jobService.findJobsByCustomerId(currentCustomerId, pageNumber).map{ job -> toDto(job)  })
 
     @GetMapping("/professional")
     @Operation(summary = "Obtiene todos los servicios realizados por un profesional")
     fun findJobsByProfessionalId(@ModelAttribute("currentProfessionalId") currentProfessionalId : Long,
-                                 @RequestParam("q", required = false) filter: String?,
-                                 @PageableDefault(page = 0, size = 10) pageable: Pageable
-    ): Page<JobDTO> = jobService.findJobsByProfessionalId(currentProfessionalId, pageable).map{ job -> toDto(job)  }
+                                 @RequestParam pageNumber: Int) : PageDTO<JobDTO> =
+        PageDTO.toDTO(jobService.findJobsByProfessionalId(currentProfessionalId, pageNumber).map{ job -> toDto(job)  })
 
     @PatchMapping("/complete/{id}")
     fun setJobAsDone(@PathVariable id: Long) = jobService.setJobAsDone(id)

--- a/src/main/kotlin/quickfix/controllers/JobController.kt
+++ b/src/main/kotlin/quickfix/controllers/JobController.kt
@@ -2,6 +2,9 @@ package quickfix.controllers
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 import quickfix.dto.job.JobDTO
@@ -37,13 +40,17 @@ class JobController(
 
     @GetMapping("/customer")
     @Operation(summary = "Obtiene todos los servicios pedidos por un usuario")
-    fun findJobsByCustomerId(@ModelAttribute("currentCustomerId") currentCustomerId : Long) : List<Job> =
-        jobService.findJobsByCustomerId(currentCustomerId)
+    fun findJobsByCustomerId(@ModelAttribute("currentCustomerId") currentCustomerId : Long,
+                             @RequestParam("q", required = false) filter: String?,
+                             @PageableDefault(page = 0, size = 10) pageable: Pageable
+    ) : Page<JobDTO> = jobService.findJobsByCustomerId(currentCustomerId, pageable).map{ job -> toDto(job)  }
 
     @GetMapping("/professional")
     @Operation(summary = "Obtiene todos los servicios realizados por un profesional")
-    fun findJobsByProfessionalId(@ModelAttribute("currentProfessionalId") currentProfessionalId : Long) : List<Job> =
-        jobService.findJobsByProfessionalId(currentProfessionalId)
+    fun findJobsByProfessionalId(@ModelAttribute("currentProfessionalId") currentProfessionalId : Long,
+                                 @RequestParam("q", required = false) filter: String?,
+                                 @PageableDefault(page = 0, size = 10) pageable: Pageable
+    ): Page<JobDTO> = jobService.findJobsByProfessionalId(currentProfessionalId, pageable).map{ job -> toDto(job)  }
 
     @PatchMapping("/complete/{id}")
     fun setJobAsDone(@PathVariable id: Long) = jobService.setJobAsDone(id)

--- a/src/main/kotlin/quickfix/dao/JobRepository.kt
+++ b/src/main/kotlin/quickfix/dao/JobRepository.kt
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Component
 import quickfix.models.Job

--- a/src/main/kotlin/quickfix/dao/JobRepository.kt
+++ b/src/main/kotlin/quickfix/dao/JobRepository.kt
@@ -1,5 +1,7 @@
 package quickfix.dao
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
@@ -11,9 +13,9 @@ import quickfix.models.Rating
 @Component
 interface JobRepository : JpaRepository<Job, Long> {
 
-    fun findAllByCustomerId(customerId: Long): List<Job>
+    fun findAllByCustomerId(customerId: Long, pageable: Pageable): Page<Job>
 
-    fun findAllByProfessionalId(professionalId: Long): List<Job>
+    fun findAllByProfessionalId(professionalId: Long, pageable: Pageable): Page<Job>
 
     @Query(
         value = """

--- a/src/main/kotlin/quickfix/dto/job/PageDTO.kt
+++ b/src/main/kotlin/quickfix/dto/job/PageDTO.kt
@@ -7,6 +7,7 @@ data class PageDTO<T>(
     var first: Boolean,
     var last: Boolean,
     var empty: Boolean,
+    var currentPage: Int,
     var totalPages: Int
 ) {
     companion object{
@@ -16,6 +17,7 @@ data class PageDTO<T>(
                 first = page.isFirst,
                 last = page.isLast,
                 empty = page.isEmpty,
+                currentPage = page.number,
                 totalPages = page.totalPages
             )
         }

--- a/src/main/kotlin/quickfix/dto/job/PageDTO.kt
+++ b/src/main/kotlin/quickfix/dto/job/PageDTO.kt
@@ -1,0 +1,23 @@
+package quickfix.dto.job
+
+import org.springframework.data.domain.Page
+
+data class PageDTO<T>(
+    var content: MutableList<T>,
+    var first: Boolean,
+    var last: Boolean,
+    var empty: Boolean,
+    var totalPages: Int
+) {
+    companion object{
+        fun toDTO(page: Page<JobDTO>): PageDTO<JobDTO> {
+            return PageDTO(
+                content = page.content,
+                first = page.isFirst,
+                last = page.isLast,
+                empty = page.isEmpty,
+                totalPages = page.totalPages
+            )
+        }
+    }
+}

--- a/src/main/kotlin/quickfix/services/JobService.kt
+++ b/src/main/kotlin/quickfix/services/JobService.kt
@@ -2,7 +2,6 @@ package quickfix.services
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,7 +18,6 @@ import quickfix.dto.professional.ProfessionalDTO
 import quickfix.models.Job
 import quickfix.models.Profession
 import quickfix.models.User
-import quickfix.utils.MAX_DEBT_ALLOWED
 import quickfix.utils.PAGE_SIZE
 import quickfix.utils.enums.JobStatus
 import quickfix.utils.exceptions.BusinessException
@@ -40,15 +38,12 @@ class JobService(
     fun findJobsByCustomerId(id: Long, pageNumber: Int): Page<Job>  =
          jobRepository.findAllByCustomerId(id, sortPage(pageNumber))
 
-
-
     fun findJobsByProfessionalId(id: Long, pageNumber: Int): Page<Job> =
          jobRepository.findAllByProfessionalId(id, sortPage(pageNumber))
 
-
-    fun sortPage(pageNumber: Int) : PageRequest {
+    private fun sortPage(pageNumber: Int) : PageRequest {
         val sort: Sort = Sort.by("date").ascending()
-       return PageRequest.of(pageNumber, PAGE_SIZE, sort)
+        return PageRequest.of(pageNumber, PAGE_SIZE, sort)
     }
 
     @Transactional(rollbackFor = [Exception::class])

--- a/src/main/kotlin/quickfix/services/JobService.kt
+++ b/src/main/kotlin/quickfix/services/JobService.kt
@@ -1,7 +1,9 @@
 package quickfix.services
 
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import quickfix.dao.JobRepository
@@ -18,6 +20,7 @@ import quickfix.models.Job
 import quickfix.models.Profession
 import quickfix.models.User
 import quickfix.utils.MAX_DEBT_ALLOWED
+import quickfix.utils.PAGE_SIZE
 import quickfix.utils.enums.JobStatus
 import quickfix.utils.exceptions.BusinessException
 import java.time.LocalDate
@@ -34,12 +37,19 @@ class JobService(
     fun getJobById(id: Long): Job =
         jobRepository.findById(id).orElseThrow { throw BusinessException() }
 
-    fun findJobsByCustomerId(id: Long, pageable: Pageable): Page<Job> =
-        jobRepository.findAllByCustomerId(id, pageable)
+    fun findJobsByCustomerId(id: Long, pageNumber: Int): Page<Job>  =
+         jobRepository.findAllByCustomerId(id, sortPage(pageNumber))
 
 
-    fun findJobsByProfessionalId(id: Long, pageable: Pageable): Page<Job> =
-        jobRepository.findAllByProfessionalId(id, pageable)
+
+    fun findJobsByProfessionalId(id: Long, pageNumber: Int): Page<Job> =
+         jobRepository.findAllByProfessionalId(id, sortPage(pageNumber))
+
+
+    fun sortPage(pageNumber: Int) : PageRequest {
+        val sort: Sort = Sort.by("date").ascending()
+       return PageRequest.of(pageNumber, PAGE_SIZE, sort)
+    }
 
     @Transactional(rollbackFor = [Exception::class])
     fun setJobAsDone(id: Long) =

--- a/src/main/kotlin/quickfix/services/JobService.kt
+++ b/src/main/kotlin/quickfix/services/JobService.kt
@@ -1,5 +1,7 @@
 package quickfix.services
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import quickfix.dao.JobRepository
@@ -32,11 +34,12 @@ class JobService(
     fun getJobById(id: Long): Job =
         jobRepository.findById(id).orElseThrow { throw BusinessException() }
 
-    fun findJobsByCustomerId(id: Long): List<Job> =
-        jobRepository.findAllByCustomerId(id)
+    fun findJobsByCustomerId(id: Long, pageable: Pageable): Page<Job> =
+        jobRepository.findAllByCustomerId(id, pageable)
 
-    fun findJobsByProfessionalId(id: Long): List<Job> =
-        jobRepository.findAllByProfessionalId(id)
+
+    fun findJobsByProfessionalId(id: Long, pageable: Pageable): Page<Job> =
+        jobRepository.findAllByProfessionalId(id, pageable)
 
     @Transactional(rollbackFor = [Exception::class])
     fun setJobAsDone(id: Long) =

--- a/src/main/kotlin/quickfix/utils/Constants.kt
+++ b/src/main/kotlin/quickfix/utils/Constants.kt
@@ -1,5 +1,4 @@
 package quickfix.utils
 
-const val MAXIMUM_DEBT = 1000.0
-
+const val MAXIMUM_DEBT: Double = 1000.0
 const val PAGE_SIZE: Int = 4

--- a/src/main/kotlin/quickfix/utils/Constants.kt
+++ b/src/main/kotlin/quickfix/utils/Constants.kt
@@ -1,3 +1,5 @@
 package quickfix.utils
 
 const val MAXIMUM_DEBT = 1000.0
+
+const val PAGE_SIZE: Int = 4


### PR DESCRIPTION
1. en jobController findJobsByCustomerId y findJobsByProfessionalId se modificaron para q puedan implementar paginacion
2. en el repositorio de jobRepository ahora los metodos findAllByCustomerId y findAllByProfessionalId saben paginacion
3. se creo un dto PageDTO para q no te devuelva todo lo q contiene el json por defecto
4. se creo una constante PAGE_SIZEahi se puede cambiar x defecto las cantidad de paginas
5. los metodos del servirce ahora entienden lo de la paginacion y le agrege un metodo adicional reutilizable sortPage 
![sort](https://github.com/user-attachments/assets/e9080721-5375-44be-8c0b-dc8b5c1c0d7f)
